### PR TITLE
ci: auto merge dependabot pull requests

### DIFF
--- a/.github/workflows/dependabot.yaml
+++ b/.github/workflows/dependabot.yaml
@@ -1,0 +1,25 @@
+name: dependabot
+on: pull_request
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    if: |
+      github.actor == 'dependabot[bot]' &&
+      github.event_name == 'pull_request' &&
+      (
+        startsWith(github.event.pull_request.title, 'chore(deps-dev):') ||
+        startsWith(github.event.pull_request.title, 'chore(deps): Bump actions/')
+      )
+    steps:
+      - name: '@dependabot merge'
+        uses: actions/github-script@v2
+        with:
+          github-token: ${{ secrets.RELEASE_TOKEN }}
+          script: |
+            await github.issues.createComment({
+              owner: context.payload.repository.owner.login,
+              repo: context.payload.repository.name,
+              issue_number: context.payload.pull_request.number,
+              body: '@dependabot merge'
+            })

--- a/package.json
+++ b/package.json
@@ -47,6 +47,15 @@
       ],
       "body-max-line-length": [
         0
+      ],
+      "subject-case": [
+        2,
+        "never",
+        [
+          "start-case",
+          "pascal-case",
+          "upper-case"
+        ]
       ]
     }
   },


### PR DESCRIPTION
Since all managed dependencies are only for dev purpose, it seems acceptable to merge all dependabot PR automatically