### PR TITLE
ci: change setup kind action

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -170,7 +170,7 @@ jobs:
     runs-on: ubuntu-latest
     if: "!contains(github.event.head_commit.message, '[skip ci]')"
     steps:
-      - uses: engineerd/setup-kind@v0.5.0
+      - uses: helm/kind-action@v1.2.0
       - run: |
           kubectl cluster-info
           kubectl api-resources

--- a/tests/assets/values.yaml
+++ b/tests/assets/values.yaml
@@ -6,3 +6,4 @@ ingress:
     - host: chart-example.local
       paths:
         - path: /
+          pathType: ImplementationSpecific


### PR DESCRIPTION
`helm/kind-action` seems to be maintained :shrug:, whereas `engineerd/setup-kind` not so much. 

